### PR TITLE
Add automatic s3 deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,5 +54,4 @@ Lastly, run the test command from the console:
 - `git tag -a vX.X.X -m 'vX.X.X'`
 - `git push --tags`
 - `npm publish`
-- Deploy packaged plugin in [mapbox-gl-js](https://github.com/mapbox/mapbox-gl-js/tree/master/plugins)
-- Update version links in documentation
+- Update version number in [GL JS example](https://github.com/mapbox/mapbox-gl-js/blob/mb-pages/docs/_posts/examples/3400-01-21-mapbox-gl-compare.html)

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,8 @@
+deployment:
+  release:
+    tag: /v[0-9]+\.[0-9]+\.[0-9]+(\-dev)?/
+    commands:
+      - aws s3 cp --recursive --acl public-read dist s3://mapbox-gl-js/plugins/$CIRCLE_PROJECT_REPONAME/$CIRCLE_TAG
+machine:
+  node:
+    version: 4


### PR DESCRIPTION
This PR adds a deployment script which publishes to s3 via CircleCI whenever a release tag is pushed to GitHub. This frees us from having to do deployment manually within the GL JS repository.