### PR TITLE
Add `slideend` event and set/get slider position

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,26 @@ new mapboxgl.Compare(before, after, {
 });
 ```
 
+### Methods
+
+```js
+compare = new mapboxgl.Compare(before, after, {
+    mousemove: true // Optional. Set to true to enable swiping during cursor movement.
+})
+
+//Get Current position - this will return the slider's current position, in pixels
+compare.currentPosition()
+
+//Set Position - this will set the slider at the specified (x) number of pixels from the left-edge of viewport
+compare.setSlider(x)
+
+//Listen to slider movement - and return current position on each slideend
+compare.on('slideend', (position) => {
+    console.log(position)
+})
+
+```
+
 Demo: https://www.mapbox.com/mapbox-gl-js/example/mapbox-gl-compare/
 
 ### Developing

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ Map movements are synced with [mapbox-gl-sync-move](https://github.com/mapbox/ma
 
 ```js
 var before = new mapboxgl.Map({
-  container: "before", // Container ID
-  style: "mapbox://styles/mapbox/light-v9"
+  container: 'before', // Container ID
+  style: 'mapbox://styles/mapbox/light-v9'
 });
 
 var after = new mapboxgl.Map({
-  container: "after", // Container ID
-  style: "mapbox://styles/mapbox/dark-v9"
+  container: 'after', // Container ID
+  style: 'mapbox://styles/mapbox/dark-v9'
 });
 
 new mapboxgl.Compare(before, after, {
@@ -38,7 +38,7 @@ compare.currentPosition();
 compare.setSlider(x);
 
 //Listen to slider movement - and return current position on each slideend
-compare.on("slideend", (e) => {
+compare.on('slideend', (e) => {
   console.log(e.currentPosition);
 });
 ```
@@ -57,7 +57,7 @@ You'll need a [Mapbox access token](https://www.mapbox.com/help/create-api-acces
 
 Tests require an MapboxAccessToken env variable to be set.
 
-    export MapboxAccessToken="YOUR ACCESS TOKEN"
+    export MapboxAccessToken='YOUR ACCESS TOKEN'
 
 Lastly, run the test command from the console:
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-## mapbox-gl-compare
+mapbox-gl-compare
+---
 
 Swipe and sync between two maps
 
@@ -57,7 +58,7 @@ You'll need a [Mapbox access token](https://www.mapbox.com/help/create-api-acces
 
 Tests require an MapboxAccessToken env variable to be set.
 
-    export MapboxAccessToken='YOUR ACCESS TOKEN'
+    export MapboxAccessToken="YOUR ACCESS TOKEN"
 
 Lastly, run the test command from the console:
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-mapbox-gl-compare
----
+## mapbox-gl-compare
 
 Swipe and sync between two maps
 
@@ -11,13 +10,13 @@ Map movements are synced with [mapbox-gl-sync-move](https://github.com/mapbox/ma
 
 ```js
 var before = new mapboxgl.Map({
-  container: 'before', // Container ID
-  style: 'mapbox://styles/mapbox/light-v9'
+  container: "before", // Container ID
+  style: "mapbox://styles/mapbox/light-v9"
 });
 
 var after = new mapboxgl.Map({
-  container: 'after', // Container ID
-  style: 'mapbox://styles/mapbox/dark-v9'
+  container: "after", // Container ID
+  style: "mapbox://styles/mapbox/dark-v9"
 });
 
 new mapboxgl.Compare(before, after, {
@@ -29,20 +28,19 @@ new mapboxgl.Compare(before, after, {
 
 ```js
 compare = new mapboxgl.Compare(before, after, {
-    mousemove: true // Optional. Set to true to enable swiping during cursor movement.
-})
+  mousemove: true // Optional. Set to true to enable swiping during cursor movement.
+});
 
 //Get Current position - this will return the slider's current position, in pixels
-compare.currentPosition()
+compare.currentPosition();
 
 //Set Position - this will set the slider at the specified (x) number of pixels from the left-edge of viewport
-compare.setSlider(x)
+compare.setSlider(x);
 
 //Listen to slider movement - and return current position on each slideend
-compare.on('slideend', (position) => {
-    console.log(position)
-})
-
+compare.on("slideend", (e) => {
+  console.log(e.currentPosition);
+});
 ```
 
 Demo: https://www.mapbox.com/mapbox-gl-js/example/mapbox-gl-compare/

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ function Compare(a, b, options) {
   }
 
   this._swiper.addEventListener('mousedown', this._onDown);
-  this._swiper.addEventListener('touchstart', this._onDown);
+  this._swiper.addEventListener('touchstart', this._onDown); 
 }
 
 Compare.prototype = {
@@ -61,6 +61,7 @@ Compare.prototype = {
     this._container.style.WebkitTransform = pos;
     this._clippedMap.getContainer().style.clip = 'rect(0, 999em, ' + this._bounds.height + 'px,' + x + 'px)';
     this._x = x;
+    this.currentPosition = this._x;
   },
 
   _onMove: function(e) {
@@ -87,6 +88,18 @@ Compare.prototype = {
     if (x < 0) x = 0;
     if (x > this._bounds.width) x = this._bounds.width;
     return x;
+  },
+
+  setSlider: function(x) {
+    this._setPosition(x);
+  },
+
+  on: function(event, func) {
+    if (event === 'slideend') {
+      document.querySelector('.mapboxgl-compare').addEventListener('mouseup', function() {
+        func(this.currentPosition);
+      })
+    }
   }
 };
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
-'use strict';
+"use strict";
 /* global mapboxgl */
 
-var syncMove = require('mapbox-gl-sync-move');
+var syncMove = require("mapbox-gl-sync-move");
+var EventEmitter = require("events").EventEmitter;
 
 function Compare(a, b, options) {
   this.options = options ? options : {};
@@ -9,12 +10,12 @@ function Compare(a, b, options) {
   this._onMove = this._onMove.bind(this);
   this._onMouseUp = this._onMouseUp.bind(this);
   this._onTouchEnd = this._onTouchEnd.bind(this);
+  this._ev = new EventEmitter();
+  this._swiper = document.createElement("div");
+  this._swiper.className = "compare-swiper";
 
-  this._swiper = document.createElement('div');
-  this._swiper.className = 'compare-swiper';
-
-  this._container = document.createElement('div');
-  this._container.className = 'mapboxgl-compare';
+  this._container = document.createElement("div");
+  this._container.className = "mapboxgl-compare";
   this._container.appendChild(this._swiper);
 
   a.getContainer().appendChild(this._container);
@@ -24,18 +25,21 @@ function Compare(a, b, options) {
   this._setPosition(this._bounds.width / 2);
   syncMove(a, b);
 
-  b.on('resize', function() {
-    this._bounds = b.getContainer().getBoundingClientRect();
-    if (this._x) this._setPosition(this._x);
-  }.bind(this));
+  b.on(
+    "resize",
+    function() {
+      this._bounds = b.getContainer().getBoundingClientRect();
+      if (this.currentPosition) this._setPosition(this.currentPosition);
+    }.bind(this)
+  );
 
   if (this.options && this.options.mousemove) {
-    a.getContainer().addEventListener('mousemove', this._onMove);
-    b.getContainer().addEventListener('mousemove', this._onMove);
+    a.getContainer().addEventListener("mousemove", this._onMove);
+    b.getContainer().addEventListener("mousemove", this._onMove);
   }
 
-  this._swiper.addEventListener('mousedown', this._onDown);
-  this._swiper.addEventListener('touchstart', this._onDown); 
+  this._swiper.addEventListener("mousedown", this._onDown);
+  this._swiper.addEventListener("touchstart", this._onDown);
 }
 
 Compare.prototype = {
@@ -46,40 +50,41 @@ Compare.prototype = {
 
   _onDown: function(e) {
     if (e.touches) {
-      document.addEventListener('touchmove', this._onMove);
-      document.addEventListener('touchend', this._onTouchEnd);
+      document.addEventListener("touchmove", this._onMove);
+      document.addEventListener("touchend", this._onTouchEnd);
     } else {
-      document.addEventListener('mousemove', this._onMove);
-      document.addEventListener('mouseup', this._onMouseUp);
+      document.addEventListener("mousemove", this._onMove);
+      document.addEventListener("mouseup", this._onMouseUp);
     }
   },
 
   _setPosition: function(x) {
     x = Math.min(x, this._bounds.width);
-    var pos = 'translate(' + x + 'px, 0)';
+    var pos = "translate(" + x + "px, 0)";
     this._container.style.transform = pos;
     this._container.style.WebkitTransform = pos;
-    this._clippedMap.getContainer().style.clip = 'rect(0, 999em, ' + this._bounds.height + 'px,' + x + 'px)';
-    this._x = x;
-    this.currentPosition = this._x;
+    this._clippedMap.getContainer().style.clip =
+      "rect(0, 999em, " + this._bounds.height + "px," + x + "px)";
+    this.currentPosition = x;
   },
 
   _onMove: function(e) {
     if (this.options && this.options.mousemove) {
-      this._setPointerEvents(e.touches ? 'auto' : 'none');
+      this._setPointerEvents(e.touches ? "auto" : "none");
     }
 
     this._setPosition(this._getX(e));
   },
 
   _onMouseUp: function() {
-    document.removeEventListener('mousemove', this._onMove);
-    document.removeEventListener('mouseup', this._onMouseUp);
+    document.removeEventListener("mousemove", this._onMove);
+    document.removeEventListener("mouseup", this._onMouseUp);
+    this.fire("slideend", { currentPosition: this.currentPosition });
   },
 
   _onTouchEnd: function() {
-    document.removeEventListener('touchmove', this._onMove);
-    document.removeEventListener('touchend', this._onTouchEnd);
+    document.removeEventListener("touchmove", this._onMove);
+    document.removeEventListener("touchend", this._onTouchEnd);
   },
 
   _getX: function(e) {
@@ -94,17 +99,24 @@ Compare.prototype = {
     this._setPosition(x);
   },
 
-  on: function(event, func) {
-    if (event === 'slideend') {
-      document.querySelector('.mapboxgl-compare').addEventListener('mouseup', function() {
-        func(this.currentPosition);
-      })
-    }
+  on: function(type, fn) {
+    this._ev.on(type, fn);
+    return this;
+  },
+
+  fire: function(type, data) {
+    this._ev.emit(type, data);
+    return this;
+  },
+
+  off: function(type, fn) {
+    this._ev.removeListener(type, fn);
+    return this;
   }
 };
 
 if (window.mapboxgl) {
   mapboxgl.Compare = Compare;
-} else if (typeof module !== 'undefined') {
+} else if (typeof module !== "undefined") {
   module.exports = Compare;
 }

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
-"use strict";
+'use strict';
 /* global mapboxgl */
 
-var syncMove = require("mapbox-gl-sync-move");
-var EventEmitter = require("events").EventEmitter;
+var syncMove = require('mapbox-gl-sync-move');
+var EventEmitter = require('events').EventEmitter;
 
 function Compare(a, b, options) {
   this.options = options ? options : {};
@@ -11,11 +11,11 @@ function Compare(a, b, options) {
   this._onMouseUp = this._onMouseUp.bind(this);
   this._onTouchEnd = this._onTouchEnd.bind(this);
   this._ev = new EventEmitter();
-  this._swiper = document.createElement("div");
-  this._swiper.className = "compare-swiper";
+  this._swiper = document.createElement('div');
+  this._swiper.className = 'compare-swiper';
 
-  this._container = document.createElement("div");
-  this._container.className = "mapboxgl-compare";
+  this._container = document.createElement('div');
+  this._container.className = 'mapboxgl-compare';
   this._container.appendChild(this._swiper);
 
   a.getContainer().appendChild(this._container);
@@ -26,7 +26,7 @@ function Compare(a, b, options) {
   syncMove(a, b);
 
   b.on(
-    "resize",
+    'resize',
     function() {
       this._bounds = b.getContainer().getBoundingClientRect();
       if (this.currentPosition) this._setPosition(this.currentPosition);
@@ -34,12 +34,12 @@ function Compare(a, b, options) {
   );
 
   if (this.options && this.options.mousemove) {
-    a.getContainer().addEventListener("mousemove", this._onMove);
-    b.getContainer().addEventListener("mousemove", this._onMove);
+    a.getContainer().addEventListener('mousemove', this._onMove);
+    b.getContainer().addEventListener('mousemove', this._onMove);
   }
 
-  this._swiper.addEventListener("mousedown", this._onDown);
-  this._swiper.addEventListener("touchstart", this._onDown);
+  this._swiper.addEventListener('mousedown', this._onDown);
+  this._swiper.addEventListener('touchstart', this._onDown);
 }
 
 Compare.prototype = {
@@ -50,41 +50,41 @@ Compare.prototype = {
 
   _onDown: function(e) {
     if (e.touches) {
-      document.addEventListener("touchmove", this._onMove);
-      document.addEventListener("touchend", this._onTouchEnd);
+      document.addEventListener('touchmove', this._onMove);
+      document.addEventListener('touchend', this._onTouchEnd);
     } else {
-      document.addEventListener("mousemove", this._onMove);
-      document.addEventListener("mouseup", this._onMouseUp);
+      document.addEventListener('mousemove', this._onMove);
+      document.addEventListener('mouseup', this._onMouseUp);
     }
   },
 
   _setPosition: function(x) {
     x = Math.min(x, this._bounds.width);
-    var pos = "translate(" + x + "px, 0)";
+    var pos = 'translate(' + x + 'px, 0)';
     this._container.style.transform = pos;
     this._container.style.WebkitTransform = pos;
     this._clippedMap.getContainer().style.clip =
-      "rect(0, 999em, " + this._bounds.height + "px," + x + "px)";
+      'rect(0, 999em, ' + this._bounds.height + 'px,' + x + 'px)';
     this.currentPosition = x;
   },
 
   _onMove: function(e) {
     if (this.options && this.options.mousemove) {
-      this._setPointerEvents(e.touches ? "auto" : "none");
+      this._setPointerEvents(e.touches ? 'auto' : 'none');
     }
 
     this._setPosition(this._getX(e));
   },
 
   _onMouseUp: function() {
-    document.removeEventListener("mousemove", this._onMove);
-    document.removeEventListener("mouseup", this._onMouseUp);
-    this.fire("slideend", { currentPosition: this.currentPosition });
+    document.removeEventListener('mousemove', this._onMove);
+    document.removeEventListener('mouseup', this._onMouseUp);
+    this.fire('slideend', { currentPosition: this.currentPosition });
   },
 
   _onTouchEnd: function() {
-    document.removeEventListener("touchmove", this._onMove);
-    document.removeEventListener("touchend", this._onTouchEnd);
+    document.removeEventListener('touchmove', this._onMove);
+    document.removeEventListener('touchend', this._onTouchEnd);
   },
 
   _getX: function(e) {
@@ -117,6 +117,6 @@ Compare.prototype = {
 
 if (window.mapboxgl) {
   mapboxgl.Compare = Compare;
-} else if (typeof module !== "undefined") {
+} else if (typeof module !== 'undefined') {
   module.exports = Compare;
 }

--- a/test/index.js
+++ b/test/index.js
@@ -18,7 +18,7 @@ test('Compare', function(t) {
     style: 'mapbox://styles/mapbox/dark-v8'
   });
 
-  var compare = new mapboxgl.Compare(a, b);
+  const compare = new mapboxgl.Compare(a, b);
 
   t.notOk(!!a.getContainer().style.clip, 'Map A is not clipped');
   t.ok(!!b.getContainer().style.clip, 'Map B is clipped');

--- a/test/index.js
+++ b/test/index.js
@@ -18,7 +18,7 @@ test('Compare', function(t) {
     style: 'mapbox://styles/mapbox/dark-v8'
   });
 
-  new mapboxgl.Compare(a, b);
+  var compare = new mapboxgl.Compare(a, b);
 
   t.notOk(!!a.getContainer().style.clip, 'Map A is not clipped');
   t.ok(!!b.getContainer().style.clip, 'Map B is clipped');
@@ -38,6 +38,10 @@ test('Compare', function(t) {
   t.equals(a.getBearing(), 20, 'Bearing is synched');
   t.equals(a.getCenter().lng, -155, 'Lng is synched');
   t.equals(a.getCenter().lat, 16, 'Lat is synched');
+
+  compare.setSlider(20);
+
+  t.equals(compare.currentPosition, 20, 'Slider has been moved')
   t.end();
 });
 


### PR DESCRIPTION
This PR adds the following

- Public currentPosition tracking (this is a clone of the internal _x value)
- Public setSlider function to programatically set slider position
- Public `slideend` event listener to allow users to track when the slider is being moved, and surface the `currentPosition` if necessary.