### PR TITLE
Maintainance

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ compare = new mapboxgl.Compare(before, after, {
 });
 
 //Get Current position - this will return the slider's current position, in pixels
-compare.currentPosition();
+compare.currentPosition;
 
 //Set Position - this will set the slider at the specified (x) number of pixels from the left-edge of viewport
 compare.setSlider(x);

--- a/example/index.js
+++ b/example/index.js
@@ -14,6 +14,6 @@ var after = new mapboxgl.Map({
   style: 'mapbox://styles/mapbox/dark-v8'
 });
 
-new mapboxgl.Compare(before, after, {
+window.compare = new mapboxgl.Compare(before, after, {
   // mousemove: true
 });

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 /* global mapboxgl */
 
-var syncMove = require('mapbox-gl-sync-move');
+var syncMove = require('@mapbox/mapbox-gl-sync-move');
 var EventEmitter = require('events').EventEmitter;
 
 function Compare(a, b, options) {

--- a/package.json
+++ b/package.json
@@ -24,16 +24,17 @@
   "author": "Mapbox",
   "license": "ISC",
   "devDependencies": {
-    "browserify": "^13.0.0",
-    "budo": "^8.0.4",
-    "envify": "^3.4.0",
-    "eslint": "^2.0.0",
-    "smokestack": "^3.4.1",
+    "browserify": "^16.2.3",
+    "budo": "^11.6.0",
+    "envify": "^4.1.0",
+    "eslint": "^5.13.0",
+    "mapbox-gl": "^0.53.0",
+    "smokestack": "^3.6.0",
     "tap-status": "^1.0.1",
-    "tape": "^4.4.0",
-    "uglify-js": "^2.6.1"
+    "tape": "^4.9.2",
+    "uglify-js": "^3.4.9"
   },
   "dependencies": {
-    "mapbox-gl-sync-move": "^0.1.0"
+    "@mapbox/mapbox-gl-sync-move": "^0.2.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -18,6 +18,10 @@ test('Compare', function(t) {
     style: 'mapbox://styles/mapbox/dark-v8'
   });
 
+  // insert the container's into the document so compare.setSlider test works
+  document.body.appendChild(a.getContainer());
+  document.body.appendChild(b.getContainer());
+
   const compare = new mapboxgl.Compare(a, b);
 
   t.notOk(!!a.getContainer().style.clip, 'Map A is not clipped');


### PR DESCRIPTION
- Upgrades dependencies to fix some errors when I ran unit tests.
- Installs mapbox-gl as devDependency as it's required to run unit tests
- Updates mapbox-gl-compare dependency which is now `@mapbox` namespaced
- Fix broken unit test for setSlider
- Fix error in documentation of compare.currentPosition

This hopefully also fixes the automatic deployment of releases to api.mapbox.com which didn't happen in the last release due to a broken unit test.

@cmtoomey would you be able to review please?

post merge:

- [ ] check to see if automated deployment happened, if not do a patch release to force it
- [ ] update mapbox-gl-js example to latest version of mapbox-gl-compare