### PR TITLE
structuring compare better

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,16 +20,19 @@ var after = new mapboxgl.Map({
   style: 'mapbox://styles/mapbox/dark-v9'
 });
 
-new mapboxgl.Compare(before, after, {
+// A selector or reference to HTML element
+var container = '#comparison-container';
+
+new mapboxgl.Compare(before, after, container, {
   mousemove: true, // Optional. Set to true to enable swiping during cursor movement.
-  orientation: 'vertical' // Optional. Sets the orientation of swiper to horizontal or vertical, defaults to vertical
+  orientation: 'vertical', // Optional. Sets the orientation of swiper to horizontal or vertical, defaults to vertical,
 });
 ```
 
 ### Methods
 
 ```js
-compare = new mapboxgl.Compare(before, after, {
+compare = new mapboxgl.Compare(before, after, container, {
   mousemove: true, // Optional. Set to true to enable swiping during cursor movement.
   orientation: 'vertical' // Optional. Sets the orientation of swiper to horizontal or vertical, defaults to vertical
 });

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ var container = '#comparison-container';
 
 new mapboxgl.Compare(before, after, container, {
   mousemove: true, // Optional. Set to true to enable swiping during cursor movement.
-  orientation: 'vertical', // Optional. Sets the orientation of swiper to horizontal or vertical, defaults to vertical,
+  orientation: 'vertical' // Optional. Sets the orientation of swiper to horizontal or vertical, defaults to vertical
 });
 ```
 

--- a/example/index.html
+++ b/example/index.html
@@ -4,8 +4,8 @@
   <meta charset='utf-8' />
   <title></title>
   <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
-  <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.46.0/mapbox-gl.js'></script>
-  <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.46.0/mapbox-gl.css' rel='stylesheet' />
+  <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v1.4.1/mapbox-gl.js'></script>
+  <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v1.4.1/mapbox-gl.css' rel='stylesheet' />
   <link href='style.css' rel='stylesheet' />
   <style>
   body { margin:0; padding:0; overflow:hidden; }

--- a/example/index.html
+++ b/example/index.html
@@ -25,8 +25,10 @@
   </style>
 </head>
 <body>
-  <div id='before' class='map'></div>
-  <div id='after' class='map'></div>
+  <div id='wrapper'>
+    <div id='before' class='map'></div>
+    <div id='after' class='map'></div>
+  </div>
   <script src='example/bundle.js'></script>
 </body>
 </html>

--- a/example/index.js
+++ b/example/index.js
@@ -14,7 +14,13 @@ var after = new mapboxgl.Map({
   style: 'mapbox://styles/mapbox/dark-v8'
 });
 
-window.compare = new mapboxgl.Compare(before, after, {
-  // mousemove: true
-  // orientation: 'vertical'
-});
+window.compare = new mapboxgl.Compare(
+  before,
+  after, 
+  '#wrapper'
+  // document.body.querySelectorAll('#wrapper')[0]
+  // {
+  //   mousemove: true
+  //   orientation: 'horizontal'
+  // }
+);

--- a/example/index.js
+++ b/example/index.js
@@ -14,13 +14,19 @@ var after = new mapboxgl.Map({
   style: 'mapbox://styles/mapbox/dark-v8'
 });
 
+// Use either of these patterns to select a container for the compare widget
+var wrapperSelector = '#wrapper';
+var wrapperElement = document.body.querySelectorAll('#wrapper')[0];
+
+// available options
+var options = {
+  mousemove: true,
+  orientation: 'horizontal'
+}
+
 window.compare = new mapboxgl.Compare(
   before,
   after, 
-  '#wrapper'
-  // document.body.querySelectorAll('#wrapper')[0]
-  // {
-  //   mousemove: true
-  //   orientation: 'horizontal'
-  // }
+  wrapperSelector
+  // options
 );

--- a/index.js
+++ b/index.js
@@ -4,32 +4,46 @@
 var syncMove = require('@mapbox/mapbox-gl-sync-move');
 var EventEmitter = require('events').EventEmitter;
 
-function Compare(a, b, options) {
+function Compare(a, b, container, options) {
   this.options = options ? options : {};
-  this._horizontal = options.orientation === 'horizontal';
+  this._mapA = a;
+  this._mapB = b;
+  this._horizontal = this.options.orientation === 'horizontal';
   this._onDown = this._onDown.bind(this);
   this._onMove = this._onMove.bind(this);
   this._onMouseUp = this._onMouseUp.bind(this);
   this._onTouchEnd = this._onTouchEnd.bind(this);
   this._ev = new EventEmitter();
   this._swiper = document.createElement('div');
-  this._swiper.className = this._horizontal ? 'compare-swiper-horizontal'  : 'compare-swiper-vertical';
+  this._swiper.className = this._horizontal ? 'compare-swiper-horizontal' : 'compare-swiper-vertical';
 
-  this._container = document.createElement('div');
-  this._container.className = this._horizontal ? 'mapboxgl-compare mapboxgl-compare-horizontal'  : 'mapboxgl-compare';
-  this._container.appendChild(this._swiper);
+  this._controlContainer = document.createElement('div');
+  this._controlContainer.className = this._horizontal ? 'mapboxgl-compare mapboxgl-compare-horizontal' : 'mapboxgl-compare';
+  this._controlContainer.className = this._controlContainer.className;
+  this._controlContainer.appendChild(this._swiper);
 
-  a.getContainer().appendChild(this._container);
+  if (typeof container === 'string' && document.body.querySelectorAll) {
+    // get container with a selector
+    var appendTarget = document.body.querySelectorAll(container)[0];
+    if (!appendTarget) {
+      throw new Error('Cannot find element with specified container selector.')
+    }
+    appendTarget.appendChild(this._controlContainer)
+  } else if (container instanceof Element && container.appendChild) {
+    // get container directly
+    container.appendChild(this._controlContainer)
+  } else {
+    throw new Error('Invalid container specified. Must be CSS selector or HTML element.')
+  }
 
-  this._clippedMap = b;
   this._bounds = b.getContainer().getBoundingClientRect();
-  var swiperPosition = (this._horizontal ? this._bounds.height : this._bounds.width)/2;
+  var swiperPosition = (this._horizontal ? this._bounds.height : this._bounds.width) / 2;
   this._setPosition(swiperPosition);
   syncMove(a, b);
 
   b.on(
     'resize',
-    function() {
+    function () {
       this._bounds = b.getContainer().getBoundingClientRect();
       if (this.currentPosition) this._setPosition(this.currentPosition);
     }.bind(this)
@@ -45,12 +59,12 @@ function Compare(a, b, options) {
 }
 
 Compare.prototype = {
-  _setPointerEvents: function(v) {
-    this._container.style.pointerEvents = v;
+  _setPointerEvents: function (v) {
+    this._controlContainer.style.pointerEvents = v;
     this._swiper.style.pointerEvents = v;
   },
 
-  _onDown: function(e) {
+  _onDown: function (e) {
     if (e.touches) {
       document.addEventListener('touchmove', this._onMove);
       document.addEventListener('touchend', this._onTouchEnd);
@@ -60,23 +74,28 @@ Compare.prototype = {
     }
   },
 
-  _setPosition: function(x) {
+  _setPosition: function (x) {
     x = Math.min(x, this._horizontal
-                    ? this._bounds.height
-                    : this._bounds.width);
+      ? this._bounds.height
+      : this._bounds.width);
     var pos = this._horizontal
-              ? 'translate(0, '+ x + 'px)'
-              : 'translate(' + x + 'px, 0)';
-    this._container.style.transform = pos;
-    this._container.style.WebkitTransform = pos;
-    var clip = this._horizontal
-                ? 'rect('+ x + 'px, 999em, ' + this._bounds.width + 'px,0)'
-                : 'rect(0, 999em, ' + this._bounds.height + 'px,' + x + 'px)';
-    this._clippedMap.getContainer().style.clip = clip;
+      ? 'translate(0, ' + x + 'px)'
+      : 'translate(' + x + 'px, 0)';
+    this._controlContainer.style.transform = pos;
+    this._controlContainer.style.WebkitTransform = pos;
+    var clipA = this._horizontal
+      ? 'rect(0, 999em, ' + x + 'px, 0)'
+      : 'rect(0, ' + x + 'px, ' + this._bounds.height + 'px, 0)';
+    var clipB = this._horizontal
+      ? 'rect(' + x + 'px, 999em, ' + this._bounds.height + 'px,0)'
+      : 'rect(0, 999em, ' + this._bounds.height + 'px,' + x + 'px)';
+    
+    this._mapA.getContainer().style.clip = clipA;
+    this._mapB.getContainer().style.clip = clipB;
     this.currentPosition = x;
   },
 
-  _onMove: function(e) {
+  _onMove: function (e) {
     if (this.options && this.options.mousemove) {
       this._setPointerEvents(e.touches ? 'auto' : 'none');
     }
@@ -86,18 +105,18 @@ Compare.prototype = {
       : this._setPosition(this._getX(e));
   },
 
-  _onMouseUp: function() {
+  _onMouseUp: function () {
     document.removeEventListener('mousemove', this._onMove);
     document.removeEventListener('mouseup', this._onMouseUp);
     this.fire('slideend', { currentPosition: this.currentPosition });
   },
 
-  _onTouchEnd: function() {
+  _onTouchEnd: function () {
     document.removeEventListener('touchmove', this._onMove);
     document.removeEventListener('touchend', this._onTouchEnd);
   },
 
-  _getX: function(e) {
+  _getX: function (e) {
     e = e.touches ? e.touches[0] : e;
     var x = e.clientX - this._bounds.left;
     if (x < 0) x = 0;
@@ -105,7 +124,7 @@ Compare.prototype = {
     return x;
   },
 
-  _getY: function(e) {
+  _getY: function (e) {
     e = e.touches ? e.touches[0] : e;
     var y = e.clientY - this._bounds.top;
     if (y < 0) y = 0;
@@ -113,21 +132,21 @@ Compare.prototype = {
     return y;
   },
 
-  setSlider: function(x) {
+  setSlider: function (x) {
     this._setPosition(x);
   },
 
-  on: function(type, fn) {
+  on: function (type, fn) {
     this._ev.on(type, fn);
     return this;
   },
 
-  fire: function(type, data) {
+  fire: function (type, data) {
     this._ev.emit(type, data);
     return this;
   },
 
-  off: function(type, fn) {
+  off: function (type, fn) {
     this._ev.removeListener(type, fn);
     return this;
   }

--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ function Compare(a, b, container, options) {
 
   b.on(
     'resize',
-    function () {
+    function() {
       this._bounds = b.getContainer().getBoundingClientRect();
       if (this.currentPosition) this._setPosition(this.currentPosition);
     }.bind(this)
@@ -59,12 +59,12 @@ function Compare(a, b, container, options) {
 }
 
 Compare.prototype = {
-  _setPointerEvents: function (v) {
+  _setPointerEvents: function(v) {
     this._controlContainer.style.pointerEvents = v;
     this._swiper.style.pointerEvents = v;
   },
 
-  _onDown: function (e) {
+  _onDown: function(e) {
     if (e.touches) {
       document.addEventListener('touchmove', this._onMove);
       document.addEventListener('touchend', this._onTouchEnd);
@@ -74,7 +74,7 @@ Compare.prototype = {
     }
   },
 
-  _setPosition: function (x) {
+  _setPosition: function(x) {
     x = Math.min(x, this._horizontal
       ? this._bounds.height
       : this._bounds.width);
@@ -95,7 +95,7 @@ Compare.prototype = {
     this.currentPosition = x;
   },
 
-  _onMove: function (e) {
+  _onMove: function(e) {
     if (this.options && this.options.mousemove) {
       this._setPointerEvents(e.touches ? 'auto' : 'none');
     }
@@ -105,18 +105,18 @@ Compare.prototype = {
       : this._setPosition(this._getX(e));
   },
 
-  _onMouseUp: function () {
+  _onMouseUp: function() {
     document.removeEventListener('mousemove', this._onMove);
     document.removeEventListener('mouseup', this._onMouseUp);
     this.fire('slideend', { currentPosition: this.currentPosition });
   },
 
-  _onTouchEnd: function () {
+  _onTouchEnd: function() {
     document.removeEventListener('touchmove', this._onMove);
     document.removeEventListener('touchend', this._onTouchEnd);
   },
 
-  _getX: function (e) {
+  _getX: function(e) {
     e = e.touches ? e.touches[0] : e;
     var x = e.clientX - this._bounds.left;
     if (x < 0) x = 0;
@@ -124,7 +124,7 @@ Compare.prototype = {
     return x;
   },
 
-  _getY: function (e) {
+  _getY: function(e) {
     e = e.touches ? e.touches[0] : e;
     var y = e.clientY - this._bounds.top;
     if (y < 0) y = 0;
@@ -132,21 +132,21 @@ Compare.prototype = {
     return y;
   },
 
-  setSlider: function (x) {
+  setSlider: function(x) {
     this._setPosition(x);
   },
 
-  on: function (type, fn) {
+  on: function(type, fn) {
     this._ev.on(type, fn);
     return this;
   },
 
-  fire: function (type, data) {
+  fire: function(type, data) {
     this._ev.emit(type, data);
     return this;
   },
 
-  off: function (type, fn) {
+  off: function(type, fn) {
     this._ev.removeListener(type, fn);
     return this;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,9 +89,9 @@
       "dev": true
     },
     "@mapbox/mapbox-gl-supported": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.4.0.tgz",
-      "integrity": "sha512-ZD0Io4XK+/vU/4zpANjOtdWfVszAgnaMPsGR6LKsWh4kLIEv9qoobTVmJPPuwuM+ZI2b3BlZ6DYw1XHVmv6YTA==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.4.1.tgz",
+      "integrity": "sha512-yyKza9S6z3ELKuf6w5n6VNUB0Osu6Z93RXPfMHLIlNWohu3KqxewLOq4lMXseYJ92GwkRAxd207Pr/Z98cwmvw==",
       "dev": true
     },
     "@mapbox/mapbox-gl-sync-move": {
@@ -1628,9 +1628,9 @@
       }
     },
     "earcut": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.1.5.tgz",
-      "integrity": "sha512-QFWC7ywTVLtvRAJTVp8ugsuuGQ5mVqNmJ1cRYeLrSHgP3nycr2RHTJob9OtM0v8ujuoKN0NY1a93J/omeTL1PA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.1.tgz",
+      "integrity": "sha512-5jIMi2RB3HtGPHcYd9Yyl0cczo84y+48lgKPxMijliNQaKAHEZJbdzLmKmdxG/mCdS/YD9DQ1gihL8mxzR0F9w==",
       "dev": true
     },
     "ecc-jsbn": {
@@ -1875,12 +1875,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
       "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
-      "dev": true
-    },
-    "esm": {
-      "version": "3.2.25",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
       "dev": true
     },
     "espree": {
@@ -2356,8 +2350,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2378,14 +2371,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2400,20 +2391,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2530,8 +2518,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2543,7 +2530,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2558,7 +2544,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2566,14 +2551,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2592,7 +2575,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2673,8 +2655,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2686,7 +2667,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2772,8 +2752,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2809,7 +2788,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2829,7 +2807,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2873,14 +2850,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -2963,9 +2938,9 @@
       }
     },
     "gl-matrix": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.0.0.tgz",
-      "integrity": "sha512-PD4mVH/C/Zs64kOozeFnKY8ybhgwxXXQYGWdB4h68krAHknWJgk9uKOn6z8YElh5//vs++90pb6csrTIDWnexA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.1.0.tgz",
+      "integrity": "sha512-526NA+3EA+ztAQi0IZpSWiM0fyQXIp7IbRvfJ4wS/TjjQD0uv0fVybXwwqqSOlq33UckivI0yMDlVtboWm3k7A==",
       "dev": true
     },
     "glob": {
@@ -3867,9 +3842,9 @@
       }
     },
     "mapbox-gl": {
-      "version": "0.53.1",
-      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-0.53.1.tgz",
-      "integrity": "sha512-dTtW/qlkUowKGlqOhE8fqII2Tj4lcokvlZwUDLnkjy4uQ9zMFnVBULGeSzzTVkj9HtQZ3Zbey10/jmoVPV9t5w==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.4.1.tgz",
+      "integrity": "sha512-4Jkf1JjsBFKlZA3BHHghgIogbbOuodjVjsdOR/j4AtfLx0G4jXrPcGvwSEVcwyQ27kVECBCn6EyRb6eUNUQujw==",
       "dev": true,
       "requires": {
         "@mapbox/geojson-rewind": "^0.4.0",
@@ -3882,8 +3857,7 @@
         "@mapbox/vector-tile": "^1.3.1",
         "@mapbox/whoots-js": "^3.1.0",
         "csscolorparser": "~1.0.2",
-        "earcut": "^2.1.5",
-        "esm": "^3.0.84",
+        "earcut": "^2.2.0",
         "geojson-vt": "^3.2.1",
         "gl-matrix": "^3.0.0",
         "grid-index": "^1.1.0",
@@ -4517,9 +4491,9 @@
       }
     },
     "pbf": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.2.0.tgz",
-      "integrity": "sha512-98Eh7rsJNJF/Im6XYMLaOW3cLnNyedlOd6hu3iWMD5I7FZGgpw8yN3vQBrmLbLodu7G784Irb9Qsv2yFrxSAGw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.2.1.tgz",
+      "integrity": "sha512-ClrV7pNOn7rtmoQVF4TS1vyU0WhYRnP92fzbfF75jAIwpnzdJXf8iTd4CMEqO4yUenH6NDqLiwjqlh6QgZzgLQ==",
       "dev": true,
       "requires": {
         "ieee754": "^1.1.12",
@@ -5853,9 +5827,9 @@
       }
     },
     "supercluster": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-6.0.1.tgz",
-      "integrity": "sha512-NTth/FBFUt9mwW03+Z6Byscex+UHu0utroIe6uXjGu9PrTuWtW70LYv9I1vPSYYIHQL74S5zAkrXrHEk0L7dGA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-6.0.2.tgz",
+      "integrity": "sha512-aa0v2HURjBTOpbcknilcfxGDuArM8khklKSmZ/T8ZXL0BuRwb5aRw95lz+2bmWpFvCXDX/+FzqHxmg0TIaJErw==",
       "dev": true,
       "requires": {
         "kdbush": "^3.0.0"
@@ -6103,9 +6077,9 @@
       }
     },
     "tinyqueue": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.2.tgz",
-      "integrity": "sha512-1oUV+ZAQaeaf830ui/p5JZpzGBw46qs1pKHcfqIc6/QxYDQuEmcBLIhiT0xAxLnekz+qxQusubIYk4cAS8TB2A==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
+      "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
       "dev": true
     },
     "tmp": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "budo": "^11.6.0",
     "envify": "^4.1.0",
     "eslint": "^5.13.0",
-    "mapbox-gl": "^0.53.0",
+    "mapbox-gl": "^1.4.1",
     "smokestack": "^3.6.0",
     "tap-status": "^1.0.1",
     "tape": "^4.9.2",

--- a/test/index.js
+++ b/test/index.js
@@ -22,7 +22,9 @@ test('Compare', function(t) {
   document.body.appendChild(a.getContainer());
   document.body.appendChild(b.getContainer());
 
-  const compare = new mapboxgl.Compare(a, b);
+  var container = document.createElement('div');
+
+  var compare = new mapboxgl.Compare(a, b, container);
 
   t.notOk(!!a.getContainer().style.clip, 'Map A is not clipped');
   t.ok(!!b.getContainer().style.clip, 'Map B is clipped');


### PR DESCRIPTION
This makes a smattering of changes to allow one to specify a container for mapbox GL compare. It was causing issues with transparency, because one map was actually layered on top of the other. So if it had transparent layers, the "before" map would peek through. This fixes this by clipping both maps instead of just one, which to me is a bit more in line with expectations.

This caused a really weird z-index issue because, believe it or not, the compare slider is actually appended to one of the maps containers, rather than being a sibling of the two maps. This asks users to specify a container, so the comparison slider isn't appended to a map, but can be put wherever the user chooses, typically in a wrapper that also holds both map canvasses.

Test that it works by creating a style with transparency, and then modifying /example to use your style IDs. That's what I did when making this thing anyways.

@jseppi for review
Closes https://github.com/mapbox/mapbox-gl-compare/issues/24