### PR TITLE
Add a remove method to the compare control.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ compare.setSlider(x);
 compare.on('slideend', (e) => {
   console.log(e.currentPosition);
 });
+
+//Remove - this will remove the compare control from the DOM and stop synchronizing the two maps.
+compare.remove();
 ```
 
 Demo: https://www.mapbox.com/mapbox-gl-js/example/mapbox-gl-compare/

--- a/example/index.html
+++ b/example/index.html
@@ -21,13 +21,21 @@
     top:0;
     bottom:0;
     width:100%;
-    }
+  }
+  .controls {
+    position:absolute;
+    top:0;
+    right:0;
+  }
   </style>
 </head>
 <body>
   <div id='wrapper'>
     <div id='before' class='map'></div>
     <div id='after' class='map'></div>
+    <div class="controls">
+        <button id="close-button">X</button>
+    </div>
   </div>
   <script src='example/bundle.js'></script>
 </body>

--- a/example/index.js
+++ b/example/index.js
@@ -30,3 +30,11 @@ window.compare = new mapboxgl.Compare(
   wrapperSelector
   // options
 );
+
+var closeButton = document.getElementById('close-button');
+
+closeButton.addEventListener('click', function(e) {
+  after.getContainer().style.display = 'none';
+  window.compare.remove();
+  after.remove();
+});

--- a/index.js
+++ b/index.js
@@ -39,15 +39,14 @@ function Compare(a, b, container, options) {
   this._bounds = b.getContainer().getBoundingClientRect();
   var swiperPosition = (this._horizontal ? this._bounds.height : this._bounds.width) / 2;
   this._setPosition(swiperPosition);
-  syncMove(a, b);
 
-  b.on(
-    'resize',
-    function() {
-      this._bounds = b.getContainer().getBoundingClientRect();
-      if (this.currentPosition) this._setPosition(this.currentPosition);
-    }.bind(this)
-  );
+  this._clearSync = syncMove(a, b);
+  this._onResize = function() {
+    this._bounds = b.getContainer().getBoundingClientRect();
+    if (this.currentPosition) this._setPosition(this.currentPosition);
+  }.bind(this);
+
+  b.on('resize', this._onResize);
 
   if (this.options && this.options.mousemove) {
     a.getContainer().addEventListener('mousemove', this._onMove);
@@ -149,6 +148,28 @@ Compare.prototype = {
   off: function(type, fn) {
     this._ev.removeListener(type, fn);
     return this;
+  },
+
+  remove: function() {
+    this._clearSync();
+    this._mapB.off('resize', this._onResize);
+    var aContainer = this._mapA.getContainer();
+
+    if (!!aContainer) {
+      aContainer.style.clip = null;
+      aContainer.removeEventListener('mousemove', this._onMove);
+    }
+
+    var bContainer = this._mapB.getContainer();
+
+    if (!!bContainer) {
+      bContainer.style.clip = null;
+      bContainer.removeEventListener('mousemove', this._onMove);
+    }
+
+    this._swiper.removeEventListener('mousedown', this._onDown);
+    this._swiper.removeEventListener('touchstart', this._onDown);
+    this._controlContainer.remove();
   }
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mapbox-gl-compare",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -95,9 +95,9 @@
       "dev": true
     },
     "@mapbox/mapbox-gl-sync-move": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-sync-move/-/mapbox-gl-sync-move-0.2.0.tgz",
-      "integrity": "sha1-ARg1ugurnSbDELAzD1EgWLLAlX0="
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-sync-move/-/mapbox-gl-sync-move-0.3.0.tgz",
+      "integrity": "sha512-ecApNLDoOdKVTZEKI/Wb5ZPinegHH1KyrEM5T6Q5QcNPDEoOFC/Gn8bK5iv4sD2akfNJacDtqqTaa1f2Oz6m+w=="
     },
     "@mapbox/point-geometry": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "uglify-js": "^3.4.9"
   },
   "dependencies": {
-    "@mapbox/mapbox-gl-sync-move": "^0.2.0"
+    "@mapbox/mapbox-gl-sync-move": "^0.3.0"
   },
   "peerDependencies": {
     "mapbox-gl": ">=0.32.1 <2.0.0"

--- a/test/index.js
+++ b/test/index.js
@@ -26,7 +26,7 @@ test('Compare', function(t) {
 
   var compare = new mapboxgl.Compare(a, b, container);
 
-  t.notOk(!!a.getContainer().style.clip, 'Map A is not clipped');
+  t.ok(!!a.getContainer().style.clip, 'Map A is clipped');
   t.ok(!!b.getContainer().style.clip, 'Map B is clipped');
 
   b.jumpTo({
@@ -47,7 +47,29 @@ test('Compare', function(t) {
 
   compare.setSlider(20);
 
-  t.equals(compare.currentPosition, 20, 'Slider has been moved')
+  t.equals(compare.currentPosition, 20, 'Slider has been moved');
+
+  compare.remove();
+
+  t.ok(!a.getContainer().style.clip, 'Map A is no longer clipped');
+  t.ok(!b.getContainer().style.clip, 'Map B is no longer clipped');
+
+  b.jumpTo({
+    bearing: 10,
+    center: {
+      lat: 26,
+      lng: -105
+    },
+    pitch: 30,
+    zoom: 5
+  });
+
+  t.equals(a.getZoom(), 3, 'Zoom is no longer synched');
+  t.equals(a.getPitch(), 20, 'Pitch is no longer synched');
+  t.equals(a.getBearing(), 20, 'Bearing is no longer synched');
+  t.equals(a.getCenter().lng, -155, 'Lng is no longer synched');
+  t.equals(a.getCenter().lat, 16, 'Lat is no longer synched');
+
   t.end();
 });
 


### PR DESCRIPTION
We've been using the compare control extensively and ran into a few scenarios where we needed to remove it from the DOM and stop syncing the maps.

Maybe this can be helpful to others as well.

Cheers.