### PR TITLE
Fire `slideend` event also on touch devices.

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,6 +127,7 @@ Compare.prototype = {
   _onTouchEnd: function() {
     document.removeEventListener('touchmove', this._onMove);
     document.removeEventListener('touchend', this._onTouchEnd);
+    this.fire('slideend', { currentPosition: this.currentPosition });
   },
 
   _getX: function(e) {


### PR DESCRIPTION
`slideend` wasn't being fired on mobile devices. This fixes that.