### PR TITLE
Add self-contained ESM bundle output for browser-direct CDN usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+v0.6.0
+---
+
+- Feature: Adds ESM bundle to `dist/` for consumption via CDN
+
 v0.5.0
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mapbox-gl-compare",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mapbox-gl-compare",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "ISC",
       "dependencies": {
         "@mapbox/mapbox-gl-sync-move": "^0.3.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mapbox-gl-compare",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Swipe and sync between two maps",
   "main": "index.js",
   "type": "module",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -2,16 +2,28 @@ import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import terser from '@rollup/plugin-terser';
 
-export default {
-    input: 'index.js',
-    output: {
-        file: 'dist/mapbox-gl-compare.js',
-        format: 'umd',
-        name: 'mapboxgl.Compare'
+const plugins = [
+    resolve({ browser: true, preferBuiltins: false }),
+    commonjs(),
+    terser()
+];
+
+export default [
+    {
+        input: 'index.js',
+        output: {
+            file: 'dist/mapbox-gl-compare.js',
+            format: 'umd',
+            name: 'mapboxgl.Compare'
+        },
+        plugins
     },
-    plugins: [
-        resolve({ browser: true, preferBuiltins: false }),
-        commonjs(),
-        terser()
-    ]
-};
+    {
+        input: 'index.js',
+        output: {
+            file: 'dist/mapbox-gl-compare.esm.js',
+            format: 'es'
+        },
+        plugins
+    }
+];


### PR DESCRIPTION
Following #68 which made index.js the ESM-first entry point for bundler consumers, this PR adds a second Rollup output — `dist/mapbox-gl-compare.esm.js`.

The existing CDN artifact (`dist/mapbox-gl-compare.js`) is a UMD bundle. When consumed via an import statement directly in the browser, the UMD format has no valid ES module exports, causing the browser to throw. This PR produces an ESM bundle that can be loaded directly via import in a browser context without a bundler.

While using ESM in a browser only context is unusual, the way we build our JSX examples in `mapbox-gl-js-docs` involves transpiling JSX code at runtime into JS with babel Standalone, and we need CDN available ESM imports to go along with the example dependencies. In this way we can keep the executable code and the code snippet we show to users as close as possible.

Ideally, this should have been included in the previous PR. I was not working far enough ahead.
